### PR TITLE
add double quotes to clone the steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,7 @@ pipeline {
                             echo "This is origin/main"
                         }
                 }
-                stage("not main) {
-
+                stage("not main") {
                     when { expression { env.GIT_BRANCH != 'origin/main' } }
                     steps {
                             echo "This is not origin/main"


### PR DESCRIPTION
Error log
00:00:03.555  WorkflowScript: 41: expecting anything but ''\n''; got it anyway @ line 41, column 35.
00:00:03.555                     stage("not main) {